### PR TITLE
Updated `tqdm==4.68.0` to `tqdm==4.64.1` requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-tqdm==4.68.0
+tqdm==4.64.1
 requests
 termcolor


### PR DESCRIPTION
tqdm==4.68.0 is not found, you can update your requirements.txt file to use the latest available version tqdm==4.64.1